### PR TITLE
Ruby 1.9 compatibility

### DIFF
--- a/ext/pcaprub/pcaprub.c
+++ b/ext/pcaprub/pcaprub.c
@@ -100,7 +100,7 @@ rbpcap_s_lookupnet(VALUE self, VALUE dev)
 	VALUE list;
 	
     Check_Type(dev, T_STRING);
-    if (pcap_lookupnet(STR2CSTR(dev), &net, &mask, eb) == -1) {
+    if (pcap_lookupnet(StringValuePtr(dev), &net, &mask, eb) == -1) {
 		rb_raise(rb_eRuntimeError, "%s", eb);
     }
 


### PR DESCRIPTION
`STR2CSTR` was deprecated in Ruby 1.8 and is removed in Ruby 1.9; this fixes pcaprub for Ruby 1.9 (it’s still working in Ruby 1.8).
