### PR TITLE
Patch for pcaprub

### DIFF
--- a/ext/pcaprub/pcaprub.c
+++ b/ext/pcaprub/pcaprub.c
@@ -223,8 +223,11 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 	if(! rbpcap_ready(rbp)) return self; 
 	
   if(rbp->type == LIVE)
-  	if(pcap_lookupnet(rbp->iface, &netid, &mask, eb) < 0)
-  		rb_raise(rb_eRuntimeError, "%s", eb);
+  	if(pcap_lookupnet(rbp->iface, &netid, &mask, eb) < 0) {
+  		netid = 0;
+  		mask = 0;
+  		rb_warn(eb);
+  	}
 
   if(pcap_compile(rbp->pd, &bpf, RSTRING_PTR(filter), 0, mask) < 0)
   	rb_raise(eBPFilterError, "invalid bpf filter");


### PR DESCRIPTION
Hi,

When setting a BPF filter against an interface that doesn't have an
IPv4 address, pcap_lookupnet() returns an error like:

"WARNING: <iface>: no IPv4 address assigned"

the tcpdump source code (tcpdump.c:1230) outputs this as a warning then
continues, setting net and mask to 0. This behaviour lets you use
BPF (with a few caveats - behaviour is different in a few cases) on
interfaces lacking an IPv4 address.

also, lib/version.rb is not valid ruby - looks like a botched merge. I haven't patched it up, since you might want a v0.12 or something instead.
