### PR TITLE
Update for ruby 2.2.x compatibility and allow compilation on x64 platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,15 @@ group :development, :test do
   # Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
   gem 'minitest', '~> 4.7.0'
   gem 'shoulda-context', '~> 1.1.6'
-  gem 'test-unit'
-  gem 'coveralls'
+
+  # test-unit moved to its own gem in ruby 2.2
+  platforms :ruby_22, :ruby_23 do
+    gem 'test-unit'
+  end
+
+  platforms :ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23 do
+    gem 'coveralls', :require => false
+  end
 end
 
 gem 'rake', '>= 0.9.2'

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,8 @@ group :development, :test do
   # Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
   gem 'minitest', '~> 4.7.0'
   gem 'shoulda-context', '~> 1.1.6'
-  platforms :ruby_19, :ruby_20, :ruby_21 do
-    gem 'coveralls', :require => false
-  end
+  gem 'test-unit'
+  gem 'coveralls'
 end
 
 gem 'rake', '>= 0.9.2'

--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -19,7 +19,7 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
   
   $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
-  $CFLAGS += " -g -Og" if with_config("debug")
+  $CFLAGS += " -g" if with_config("debug")
   $LDFLAGS = "-L#{pcap_libdir}"
   $LDFLAGS += " -g" if with_config("debug")
   
@@ -34,7 +34,7 @@ elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "\\lib")
 
   $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
-  $CFLAGS += " -g -Og" if with_config("debug")
+  $CFLAGS += " -g" if with_config("debug")
   $LDFLAGS = "/link /LIBPATH:#{pcap_libdir}"
   $LDFLAGS += " -g" if with_config("debug")
   have_header("ruby/thread.h")
@@ -78,7 +78,7 @@ else
   have_library("pcap", "pcap_open_live", ["pcap.h"])
   have_library("pcap", "pcap_setnonblock", ["pcap.h"])
   
-  $CFLAGS = "-g -Og" if with_config("debug")
+  $CFLAGS = "-g" if with_config("debug")
   $LDFLAGS = "-g" if with_config("debug")
 end
 

--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -4,8 +4,7 @@ extension_name = 'pcaprub_c'
 puts "\n[*] Running checks for #{extension_name} code..."
 puts("platform is #{RUBY_PLATFORM}")
 
-if /i386-mingw32/ =~ RUBY_PLATFORM
-
+if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
   unless  have_library("ws2_32" ) and
     have_library("iphlpapi") and
     have_header("windows.h") and
@@ -18,19 +17,30 @@ if /i386-mingw32/ =~ RUBY_PLATFORM
   pcap_dir        = with_config("pcap-dir", "C:/WpdPack")
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "/include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
-  $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
-  $LDFLAGS = "-L#{pcap_libdir}"
   
+  $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
+  $CFLAGS += " -g -Og" if with_config("debug")
+  $LDFLAGS = "-L#{pcap_libdir}"
+  $LDFLAGS += " -g" if with_config("debug")
+  
+  have_header("ruby/thread.h")
+  have_func("rb_thread_blocking_region") # Pre ruby 2.2
+  have_func("rb_thread_call_without_gvl") # Post ruby 2.2
   have_library("wpcap", "pcap_open_live")
   have_library("wpcap", "pcap_setnonblock")
-
-elsif /i386-mswin32/ =~ RUBY_PLATFORM
+elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
   pcap_dir        = with_config("pcap-dir", "C:\\WpdPack")
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "\\include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "\\lib")
 
   $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
+  $CFLAGS += " -g -Og" if with_config("debug")
   $LDFLAGS = "/link /LIBPATH:#{pcap_libdir}"
+  $LDFLAGS += " -g" if with_config("debug")
+  have_header("ruby/thread.h")
+  have_func("rb_thread_blocking_region") # Pre ruby 2.2
+  have_func("rb_thread_call_without_gvl") # Post ruby 2.2
+
   have_library("wpcap", "pcap_open_live")
   have_library("wpcap", "pcap_setnonblock")
 else
@@ -61,8 +71,15 @@ else
 
   dir_config("pcap", header_dirs, lib_dirs)
 
+  have_header("ruby/thread.h")
+  have_func("rb_thread_blocking_region") # Pre ruby 2.2
+  have_func("rb_thread_call_without_gvl") # Post ruby 2.2
+
   have_library("pcap", "pcap_open_live", ["pcap.h"])
   have_library("pcap", "pcap_setnonblock", ["pcap.h"])
+  
+  $CFLAGS = "-g -Og" if with_config("debug")
+  $LDFLAGS = "-g" if with_config("debug")
 end
 
 create_makefile(extension_name)

--- a/ext/pcaprub_c/pcaprub.c
+++ b/ext/pcaprub_c/pcaprub.c
@@ -1,9 +1,12 @@
 #include "ruby.h"
 
+#ifdef HAVE_RUBY_THREAD_H
+  #include "ruby/thread.h"
+#endif
+
 #ifdef MAKE_TRAP
 #include "rubysig.h"
 #endif
-
 
 #include <pcap.h>
 #if defined(WIN32)
@@ -1244,6 +1247,10 @@ rbpcap_thread_wait_handle(HANDLE fno)
 #if MAKE_TRAP
   // Ruby 1.8 doesn't support rb_thread_blocking_region
   result = rb_thread_polling();
+#elif defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
+  result = (VALUE)rb_thread_call_without_gvl(
+      rbpcap_thread_wait_handle_blocking,
+	  fno, RUBY_UBF_IO, 0);
 #else
   result = (VALUE)rb_thread_blocking_region(
       rbpcap_thread_wait_handle_blocking,

--- a/lib/pcaprub/version.rb
+++ b/lib/pcaprub/version.rb
@@ -4,7 +4,7 @@ module PCAPRUB #:nodoc:
 
     MAJOR = 0
     MINOR = 12
-    TINY = 2
+    TINY = 1
 
     STRING = [MAJOR, MINOR, TINY].join('.')
 

--- a/lib/pcaprub/version.rb
+++ b/lib/pcaprub/version.rb
@@ -4,7 +4,7 @@ module PCAPRUB #:nodoc:
 
     MAJOR = 0
     MINOR = 12
-    TINY = 1
+    TINY = 2
 
     STRING = [MAJOR, MINOR, TINY].join('.')
 


### PR DESCRIPTION
**This isn't ready to merge quite yet, and I was hoping for some feedback because I'm stumped**

Some background:

* Ruby deprecated various thread functions in Ruby 2.2 (see: https://bugs.ruby-lang.org/issues/9502).
* pcaprub doesn't compile against Ruby 2.2 because of the above.
* Didn't see any support for x64 based builds (also caused compilation to fail).

Things that currently work with this pull request:

* Compiles/installs successfully on x64-mingw32 platform (no access to i386 unfortunately), maybe Travis will catch this if something's up.
* Compiles/installs successfully on Mac OSX 10.11
* Tests run and complete on Mac OSX 10.11 (1 error, looking into it still)

Things that currently don't work with this pull request:

* `rake test` fails spectacularly with a SEGFAULT on Windows (x64-mingw32)
  * [Bug report](https://gist.github.com/bubbadean123/61713867098fa9ecd4b1) suggests that the issue is coming from `Pcap.lookupdev`
  * [GDB output](https://gist.github.com/bubbadean123/125feb250f315bf75998) suggests that it's coming from Init_pcaprub_c(), but can't tell from where specifically since I can't get it to compile with debug symbols despite mingw's gcc getting passed the `-g` flag. **This is what I'm hoping to get some feedback on.** I'm unfortunately not the most proficient with Windows development (sorry!). I've tried a couple different things, but most everything has been a shot in the dark.
  * Using: `ruby 2.2.3p173 (2015-08-18 revision 51636) [x64-mingw32]` From: http://rubyinstaller.org/ (specifically: http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.3-x64.exe)
  * Most recent [mkmf.log](https://gist.github.com/bubbadean123/e9f2996c3fc24de34bfb)
  * Most recent [Makefile](https://gist.github.com/bubbadean123/9d1dcc5cda1051ff3eec)

Let me know if you have any questions, I'm more than happy to help out here :smile: 
