### PR TITLE
Bump ruby versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: ruby
 before_install:
  - sudo apt-get install libpcap-dev -qq
- - gem update bundler
 before_script:
  - travis_retry gem update bundler
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
+env:
+  rvmsudo_secure_path: 1
+cache: bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,8 @@ group :development, :test do
   # Prevent occasions where minitest is not bundled in packaged versions of ruby (see #3826)
   gem 'minitest', '~> 4.7.0'
   gem 'shoulda-context', '~> 1.1.6'
-
-  # test-unit moved to its own gem in ruby 2.2
-  platforms :ruby_22, :ruby_23 do
-    gem 'test-unit'
-  end
-
-  platforms :ruby_20, :ruby_21, :ruby_22, :ruby_23 do
-    gem 'coveralls', :require => false
-  end
+  gem 'test-unit'
+  gem 'coveralls', :require => false
 end
 
 gem 'rake-compiler', '>= 0.6.0'

--- a/README.rdoc
+++ b/README.rdoc
@@ -21,9 +21,7 @@ For packet processing capability look at ruby gems PCAPFU, PCAPLET, etc..
 == Requirements
 
 MRI POSIX Ruby (Native compilation) [Travis-CI Tested]
-  Ruby 1.8.7  (EOL June 2014)
-  Ruby 1.9.3
-  ~> Ruby 2.x 
+  ~> Ruby 2.4
 
   libpcap - http://www.tcpdump.org
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler --quiet
   - bundler --version
   - bundle install
   - cinst 7zip.commandline
   - cinst winpcap
-  - appveyor DownloadFile http://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+  - appveyor DownloadFile http://www.winpcap.org/install/bin/WpdPack_%wpdpack%.zip
   - dir
-  - 7za x .\WpdPack_4_1_2.zip -oc:\
+  - 7za x .\WpdPack_%wpdpack%.zip -oc:\
 build_script:
   - rake gem
 test_script:
@@ -27,13 +27,15 @@ artifacts:
 
 # https://www.appveyor.com/docs/installed-software#ruby
 environment:
+  wpdpack: 4_1_2
   matrix:
-    - ruby_version: "193"
-    - ruby_version: "200"
-    # - ruby_version: "200-x64" (Winpcap.h is not linking under 64bit ruby builds)
-    - ruby_version: "21"
-    # - ruby_version: "21-x64"
-    - ruby_version: "22"
+    - ruby_version: "24-x64"
+    - ruby_version: "24"
+    - ruby_version: "25-x64"
+    - ruby_version: "25"
+    - ruby_version: "26-x64"
+    - ruby_version: "26"
+
 
 cache:
   - C:\Users\appveyor\AppData\Local\Temp\chocolatey

--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -18,6 +18,10 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "/include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
   
+  if /x64-mingw32/ =~ RUBY_PLATFORM
+    pcap_libdir += "/x64"
+  end
+
   $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
   $CFLAGS += " -g" if with_config("debug")
   $LDFLAGS = "-L#{pcap_libdir}"
@@ -32,6 +36,10 @@ elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
   pcap_dir        = with_config("pcap-dir", "C:\\WpdPack")
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "\\include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "\\lib")
+
+  if /x64-mingw32/ =~ RUBY_PLATFORM
+    pcap_libdir += "\\x64"
+  end
 
   $CFLAGS  = "-DWIN32 -I#{pcap_includedir}"
   $CFLAGS += " -g" if with_config("debug")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,5 @@ require "minitest/autorun"
 require 'test/unit'
 require 'pcaprub'
 
-
-if RUBY_VERSION >= "1.9.2"
-  require 'coveralls'
-  Coveralls.wear!
-end
-
+require 'coveralls'
+Coveralls.wear!

--- a/test/test_pcaprub_unit.rb
+++ b/test/test_pcaprub_unit.rb
@@ -71,7 +71,7 @@ class Pcap::UnitTest < Test::Unit::TestCase
     d = Pcap.lookupdev
     o = Pcap.open_live(d, 65535, true, 1)
     r = o.datalink
-    assert_equal(Fixnum, r.class)
+    assert_equal(Integer, r.class)
   end
 
   def test_pcap_snapshot


### PR DESCRIPTION
All EOL versions have been dropped. 2.4 through 2.6 are kept, plus
ruby-head.