### PR TITLE
Add support for x64-mingw-ucrt

### DIFF
--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -4,7 +4,7 @@ extension_name = 'pcaprub_c'
 puts "\n[*] Running checks for #{extension_name} code..."
 puts("platform is #{RUBY_PLATFORM}")
 
-if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
+if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-mingw-ucrt/ =~ RUBY_PLATFORM
   unless  have_library("ws2_32" ) and
     have_library("iphlpapi") and
     have_header("windows.h") and
@@ -17,8 +17,8 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
   pcap_dir        = with_config("pcap-dir", "C:/WpdPack")
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "/include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
-  
-  if /x64-mingw32/ =~ RUBY_PLATFORM
+
+  if /x64-mingw32/ =~ RUBY_PLATFORM || /x64-mingw-ucrt/ =~ RUBY_PLATFORM
     pcap_libdir += "/x64"
   end
 
@@ -26,7 +26,7 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM
   $CFLAGS += " -g" if with_config("debug")
   $LDFLAGS = "-L#{pcap_libdir}"
   $LDFLAGS += " -g" if with_config("debug")
-  
+
   have_header("ruby/thread.h")
   have_func("rb_thread_blocking_region") # Pre ruby 2.2
   have_func("rb_thread_call_without_gvl") # Post ruby 2.2
@@ -85,7 +85,7 @@ else
 
   have_library("pcap", "pcap_open_live", ["pcap.h"])
   have_library("pcap", "pcap_setnonblock", ["pcap.h"])
-  
+
   $CFLAGS = "-g" if with_config("debug")
   $LDFLAGS = "-g" if with_config("debug")
 end


### PR DESCRIPTION
Closes https://github.com/pcaprub/pcaprub/issues/62

Add support for the `x64-mingw-ucrt` platform string:

```
C:\Users\vagrant>ruby --version
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x64-mingw-ucrt]

C:\Users\vagrant>ruby -e 'puts RUBY_PLATFORM'
x64-mingw-ucrt
```

Example of tests now passing (if https://github.com/pcaprub/pcaprub/pull/63 is merged to fix the broken windows test):
![image](https://user-images.githubusercontent.com/1271782/227695695-77ce3a5b-d6ce-4dda-8f69-89118b36d912.png)

My replication steps were creating a fresh windows box; And installing the latest Ruby 3.1 devkit with choco.
Previously you would get this error - as the `extconf.rb` logic defaulted to using Linux instead of windows:

```
C:/tools/ruby31/bin/ruby.exe -I. -r.rake-compiler-siteconf.rb ../../../../ext/pcaprub_c/extconf.rb

[*] Running checks for pcaprub_c code...
platform is x64-mingw-ucrt
checking for ruby/thread.h... yes
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_without_gvl()... yes
checking for pcap_open_live() in -lpcap... no
checking for pcap_setnonblock() in -lpcap... no
creating Makefile
cd -
cd tmp/x64-mingw-ucrt/pcaprub_c/3.1.3
C:\tools\msys64\usr\bin/make.exe
generating pcaprub_c-x64-mingw-ucrt.def
compiling ../../../../ext/pcaprub_c/pcaprub.c
c:/pcaprub/ext/pcaprub_c/pcaprub.c:11:10: fatal error: pcap.h: No such file or directory
   11 | #include <pcap.h>
      |          ^~~~~~~~
compilation terminated.
make: *** [Makefile:247: pcaprub.o] Error 1
rake aborted!
Command failed with status (2): [C:\tools\msys64\usr\bin/make.exe...]

Tasks: TOP => default => compile => compile:x64-mingw-ucrt => compile:pcaprub_c:x64-mingw-ucrt => copy:pcaprub_c:x64-mingw-ucrt:3.1.3 => tmp/x64-mingw-ucrt/pcaprub_c/3.1.3/pcaprub_c.so
(See full trace by running task with --trace)

c:\pcaprub>
```