### PR TITLE
Fix github action failures

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,6 +32,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 
@@ -39,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/ext/pcaprub_c/pcaprub.c
+++ b/ext/pcaprub_c/pcaprub.c
@@ -981,7 +981,7 @@ rbpcap_each_data(VALUE self)
   if(! rbpcap_ready(rbp)) return self;
 
 #if defined(WIN32)
-  fno = (int)pcap_getevent(rbp->pd);
+  fno = (HANDLE)pcap_getevent(rbp->pd);
 #else
   fno = pcap_get_selectable_fd(rbp->pd);
 #endif
@@ -1023,7 +1023,7 @@ rbpcap_each_packet(VALUE self)
   if(! rbpcap_ready(rbp)) return self;
 
 #if defined(WIN32)
-  fno = (int)pcap_getevent(rbp->pd);
+  fno = (HANDLE)pcap_getevent(rbp->pd);
 #else
   fno = pcap_get_selectable_fd(rbp->pd);
 #endif
@@ -1241,12 +1241,12 @@ rbpacket_data(VALUE self)
 }
 
 #if defined(WIN32)
-static VALUE
+static void *
 rbpcap_thread_wait_handle_blocking(void *data)
 {
   VALUE result;
   result = (VALUE)WaitForSingleObject(data, 100);
-  return result;
+  return (void *) result;
 }
 
 /*


### PR DESCRIPTION
Testing Ruby 3.3 and fixing the `int-conversion` and `incompatible-pointer-types` errors:

```
make.exe DESTDIR\=
generating pcaprub_c-x64-mingw32.def
compiling pcaprub.c
In file included from C:/WpdPack/include/pcap/pcap.h:41,
                 from C:/WpdPack/include/pcap.h:45,
                 from pcaprub.c:11:
C:/WpdPack/include/pcap-stdinc.h:64:9: warning: "snprintf" redefined
   64 | #define snprintf _snprintf
      |         ^~~~~~~~
In file included from
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/ruby.h:144,
from
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby.h:38,
                 from pcaprub.c:1:
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/subst.h:14:9:
note: this is the location of the previous definition
   14 | #define snprintf ruby_snprintf
      |         ^~~~~~~~
C:/WpdPack/include/pcap-stdinc.h:65:9: warning: "vsnprintf" redefined
   65 | #define vsnprintf _vsnprintf
      |         ^~~~~~~~~
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/subst.h:15:9:
note: this is the location of the previous definition
   15 | #define vsnprintf ruby_vsnprintf
      |         ^~~~~~~~~
pcaprub.c: In function 'rbpcap_each_data':
pcaprub.c:984:9: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
  984 |   fno = (int)pcap_getevent(rbp->pd);
      |         ^
pcaprub.c:984:7: error: assignment to 'HANDLE' {aka 'void *'} from 'int' makes
pointer from integer without a cast [-Wint-conversion]
  984 |   fno = (int)pcap_getevent(rbp->pd);
      |       ^
pcaprub.c: In function 'rbpcap_each_packet':
pcaprub.c:1026:9: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
 1026 |   fno = (int)pcap_getevent(rbp->pd);
      |         ^
pcaprub.c:1026:7: error: assignment to 'HANDLE' {aka 'void *'} from 'int' makes
pointer from integer without a cast [-Wint-conversion]
 1026 |   fno = (int)pcap_getevent(rbp->pd);
      |       ^
pcaprub.c: In function 'rbpcap_thread_wait_handle':
pcaprub.c:1266:7: error: passing argument 1 of 'rb_thread_call_without_gvl' from
incompatible pointer type [-Wincompatible-pointer-types]
 1266 |       rbpcap_thread_wait_handle_blocking,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |       |
      |       VALUE (*)(void *) {aka long long unsigned int (*)(void *)}
In file included from pcaprub.c:4:
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/thread.h:24:42:
note: expected 'void * (*)(void *)' but argument is of type 'VALUE (*)(void *)'
{aka 'long long unsigned int (*)(void *)'}
   24 | void *rb_thread_call_without_gvl(void *(*func)(void *), void *data1,
      |                                  ~~~~~~~~^~~~~~~~~~~~~
make: *** [Makefile:246: pcaprub.o] Error 1
```

Tests passing:

![image](https://github.com/pcaprub/pcaprub/assets/60357436/a3b2095d-4bf4-447b-a07b-c114533ad245)
