### PR TITLE
Add Npcap support

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,19 +19,66 @@ permissions:
 on: [push, pull_request]
 
 jobs:
-  verify:
+  verify-windows:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - windows-latest
-          - ubuntu-latest
-        ruby:
-          - '3.0'
-          - '3.1'
-          - '3.2'
-          - '3.3'
+        os: [windows-latest]
+        pcap: [winpcap, npcap]
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.pcap }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup Ruby
+        env:
+          BUNDLE_WITHOUT: "coverage development"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
+
+      - name: Install system dependencies (Windows - winpcap)
+        if: matrix.pcap == 'winpcap'
+        shell: pwsh
+        run: |
+          $script = "$(Get-Location)\script\installwinpcap.ps1"
+          Write-Host $script
+          . $script
+
+      - name: Install system dependencies (Windows - npcap)
+        if: matrix.pcap == 'npcap'
+        shell: pwsh
+        run: |
+          $script = "$(Get-Location)\script\installnpcap.ps1"
+          Write-Host $script
+          . $script
+
+      - name: build
+        run: |
+          bundle install
+          rake gem
+
+      - name: test
+        run: |
+          bundle exec rake
+
+  verify-unix:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 
@@ -57,25 +104,11 @@ jobs:
         run: |
           sudo apt-get install libpcap-dev
 
-      - name: Install system dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $script = "$(Get-Location)\script\installwinpcap.ps1"
-          Write-Host $script
-          . $script
-
       - name: build
         run: |
           bundle install
           rake gem
 
-      - name: test (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          bundle exec rake
-
-      - name: test (Unix)
-        if: runner.os != 'Windows'
+      - name: test
         run: |
           sudo --preserve-env=PATH env bundle exec rake

--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -3,6 +3,10 @@ extension_name = 'pcaprub_c'
 
 puts "\n[*] Running checks for #{extension_name} code..."
 puts("platform is #{RUBY_PLATFORM}")
+npcap_sdk = 'C:/npcap-sdk'
+winpcap_sdk = 'C:/WpdPack'
+# Default to npcap if it exists, otherwise fallback to winpcap
+pcap_sdk = File.directory?(npcap_sdk) ? npcap_sdk : winpcap_sdk
 
 if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-mingw-ucrt/ =~ RUBY_PLATFORM
   unless  have_library("ws2_32" ) and
@@ -14,7 +18,7 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-min
     exit
   end
 
-  pcap_dir        = with_config("pcap-dir", "C:/WpdPack")
+  pcap_dir        = with_config("pcap-dir", pcap_sdk)
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "/include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
 
@@ -28,12 +32,15 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-min
   $LDFLAGS += " -g" if with_config("debug")
 
   have_header("ruby/thread.h")
+  if have_header(pcap_includedir + "/Win32-Extensions.h", pcap_includedir + "/pcap.h")
+    append_cflags("-DHAVE_WIN32_EXTENSIONS_H")
+  end
   have_func("rb_thread_blocking_region") # Pre ruby 2.2
   have_func("rb_thread_call_without_gvl") # Post ruby 2.2
   have_library("wpcap", "pcap_open_live")
   have_library("wpcap", "pcap_setnonblock")
 elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
-  pcap_dir        = with_config("pcap-dir", "C:\\WpdPack")
+  pcap_dir        = with_config("pcap-dir", pcap_sdk)
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "\\include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "\\lib")
 
@@ -46,6 +53,9 @@ elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
   $LDFLAGS = "/link /LIBPATH:#{pcap_libdir}"
   $LDFLAGS += " -g" if with_config("debug")
   have_header("ruby/thread.h")
+  if have_header(pcap_includedir + "/Win32-Extensions.h", pcap_includedir + "/pcap.h")
+    append_cflags("-DHAVE_WIN32_EXTENSIONS_H")
+  end
   have_func("rb_thread_blocking_region") # Pre ruby 2.2
   have_func("rb_thread_call_without_gvl") # Post ruby 2.2
 

--- a/ext/pcaprub_c/extconf.rb
+++ b/ext/pcaprub_c/extconf.rb
@@ -3,10 +3,10 @@ extension_name = 'pcaprub_c'
 
 puts "\n[*] Running checks for #{extension_name} code..."
 puts("platform is #{RUBY_PLATFORM}")
-npcap_sdk = 'C:/npcap-sdk'
-winpcap_sdk = 'C:/WpdPack'
+default_npcap_sdk = 'C:/npcap-sdk'
+default_winpcap_sdk = 'C:/WpdPack'
 # Default to npcap if it exists, otherwise fallback to winpcap
-pcap_sdk = File.directory?(npcap_sdk) ? npcap_sdk : winpcap_sdk
+default_pcap_sdk = File.directory?(default_npcap_sdk) ? default_npcap_sdk : default_winpcap_sdk
 
 if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-mingw-ucrt/ =~ RUBY_PLATFORM
   unless  have_library("ws2_32" ) and
@@ -18,7 +18,7 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-min
     exit
   end
 
-  pcap_dir        = with_config("pcap-dir", pcap_sdk)
+  pcap_dir        = with_config("pcap-dir", default_pcap_sdk)
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "/include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "/lib")
 
@@ -40,7 +40,7 @@ if /i386-mingw32/ =~ RUBY_PLATFORM || /x64-mingw32/ =~ RUBY_PLATFORM || /x64-min
   have_library("wpcap", "pcap_open_live")
   have_library("wpcap", "pcap_setnonblock")
 elsif /i386-mswin32/ =~ RUBY_PLATFORM || /x64-mswin32/ =~ RUBY_PLATFORM
-  pcap_dir        = with_config("pcap-dir", pcap_sdk)
+  pcap_dir        = with_config("pcap-dir", default_pcap_sdk)
   pcap_includedir = with_config("pcap-includedir", pcap_dir + "\\include")
   pcap_libdir     = with_config("pcap-libdir", pcap_dir + "\\lib")
 

--- a/ext/pcaprub_c/pcaprub.c
+++ b/ext/pcaprub_c/pcaprub.c
@@ -9,8 +9,11 @@
 #endif
 
 #include <pcap.h>
+// Win32-Extensions only exist in winpcap not npcap
 #if defined(WIN32)
-#include <Win32-Extensions.h>
+  #ifdef HAVE_WIN32_EXTENSIONS_H
+    #include <Win32-Extensions.h>
+  #endif
 #endif
 
 #if !defined(WIN32)
@@ -407,7 +410,7 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 {
   char eb[PCAP_ERRBUF_SIZE];
   rbpcap_t *rbp;
-  u_int32_t mask = 0, netid = 0;
+  uint32_t mask = 0, netid = 0;
   struct bpf_program bpf;
 
   Data_Get_Struct(self, rbpcap_t, rbp);
@@ -452,7 +455,7 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 static VALUE
 rbpcap_compile(VALUE self, VALUE filter) {
   struct bpf_program bpf;
-  u_int32_t mask = 0;
+  uint32_t mask = 0;
   rbpcap_t *rbp;
 
   Data_Get_Struct(self, rbpcap_t, rbp);

--- a/ext/pcaprub_c/pcaprub.c
+++ b/ext/pcaprub_c/pcaprub.c
@@ -410,7 +410,7 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 {
   char eb[PCAP_ERRBUF_SIZE];
   rbpcap_t *rbp;
-  uint32_t mask = 0, netid = 0;
+  bpf_u_int32 mask = 0, netid = 0;
   struct bpf_program bpf;
 
   Data_Get_Struct(self, rbpcap_t, rbp);
@@ -455,7 +455,7 @@ rbpcap_setfilter(VALUE self, VALUE filter)
 static VALUE
 rbpcap_compile(VALUE self, VALUE filter) {
   struct bpf_program bpf;
-  uint32_t mask = 0;
+  bpf_u_int32 mask = 0;
   rbpcap_t *rbp;
 
   Data_Get_Struct(self, rbpcap_t, rbp);

--- a/lib/pcaprub.rb
+++ b/lib/pcaprub.rb
@@ -2,6 +2,15 @@ module PCAPRUB
   $:.unshift(File.dirname(__FILE__))
   require 'pcaprub/common'
   require 'pcaprub/version'
+
+  if RUBY_PLATFORM =~/(mswin|mingw)/i
+    # On Windows load npcap first if it exists, will fall back to winpcap if that's installed
+    npcap_path = "C:\\Windows\\System32\\Npcap"
+    if File.directory?(npcap_path)
+      RubyInstaller::Runtime.add_dll_directory(npcap_path)
+    end
+  end
+
   require 'pcaprub/ext'
 end
 

--- a/script/installnpcap.ps1
+++ b/script/installnpcap.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = 'Stop'
+
+# 1) Install the npcap developer files for compiling the pcaprub_c.so file - this happens when rake is run
+choco install -y --limitoutput 7zip
+$wpdPcapZip = 'C:\Windows\Temp\npcap-sdk-1.13.zip'
+(New-Object System.Net.WebClient).DownloadFile('https://npcap.com/dist/npcap-sdk-1.13.zip', $wpdPcapZip)
+Get-ChildItem $wpdPcapZip
+C:\ProgramData\chocolatey\bin\7z.exe x $wpdPcapZip -aoa -o"C:\npcap-sdk\"
+Get-ChildItem C:\
+
+if (!(Test-Path -Path C:\npcap-sdk\Lib\x64\wpcap.lib)) {
+    throw "failed extracting wpcap.lib for compilation"
+}
+
+# 2) Install the winpcap dll - required at runtime when tests are being run as part of 'bundle exec rake'
+$npcapExe = "C:\Windows\Temp\npcap-0.90.exe"
+(New-Object System.Net.WebClient).DownloadFile('https://nmap.org/npcap/dist/npcap-0.90.exe', $npcapExe)
+Start-Process -FilePath "C:\Windows\Temp\npcap-0.90.exe" -ArgumentList "/S" -wait
+
+if (!(Test-Path -Path C:\Windows\System32\Npcap\wpcap.dll)) {
+    throw "failed installing wpcap.dll for runtime tests"
+}

--- a/test/test_pcaprub_unit.rb
+++ b/test/test_pcaprub_unit.rb
@@ -166,12 +166,11 @@ class Pcap::UnitTest < Test::Unit::TestCase
     v = Pcap.lib_version.split
     if RUBY_PLATFORM =~ /mingw/
       winpcap = 'WinPcap' == v[0]
-      npcap = 'npcap' == v[0]
+      npcap = 'Npcap' == v[0]
       assert winpcap || npcap
     else
       assert_equal "libpcap", v[0]
     end
     assert_equal "version", v[1]
-    assert_equal 3, v[2].split('.').size
   end
 end

--- a/test/test_pcaprub_unit.rb
+++ b/test/test_pcaprub_unit.rb
@@ -165,7 +165,9 @@ class Pcap::UnitTest < Test::Unit::TestCase
   def test_lib_version
     v = Pcap.lib_version.split
     if RUBY_PLATFORM =~ /mingw/
-      assert_equal "WinPcap", v[0]
+      winpcap = 'WinPcap' == v[0]
+      npcap = 'npcap' == v[0]
+      assert winpcap || npcap
     else
       assert_equal "libpcap", v[0]
     end


### PR DESCRIPTION
Resolves #59 

Adds support for Npcap remaining fully compatible with Winpcap. 
If Npcap is installed on the system then Npcap will be used otherwise it will fallback to winpcap, the same is true at compilation time it will first check for the `npcap-sdk` folder before the `WpdPack` folder (compiling against npcap-sdk is also compatible with Winpcap at runtime) but this can still be overwritten with the `--with-pcap-dir` flag

Additionally refactored part of the CI tests to separate out the windows and unix tests while adding a second set of windows tests for compiling and running against Npcap. Using the latest version of npcap-sdk but an older version (0.90) of npcap as newer version have limitations on performing a silent install which was necessary for automated testing

Also performed some manual testing with metasploits `psnuffle` module which now works when pcaprub uses either npcap or winpcap

